### PR TITLE
Documentation: Fix typo at Domain Options

### DIFF
--- a/docs/options/domain-options.md
+++ b/docs/options/domain-options.md
@@ -9,7 +9,7 @@ Each configuration is identified by a domain name and can have the following opt
 | hide_config_entities     | boolean | `true`            | Set to `false` to include config-entities to the dashboard.               |
 | hide_diagnostic_entities | boolean | `true`            | Set to `false` to include diagnostic-entities to the dashboard.           |
 | order                    | number  | `unset`           | Ordering position of the domain entities in a view.                       |
-| showControls             | boolean | `true`            | Weather to show controls in a view, to switch all entities of the domain. |
+| showControls             | boolean | `true`            | Whether to show controls in a view, to switch all entities of the domain. |
 | stack_count              | object  | `{_: 1}`          | Cards per row.[^1]                                                        |
 | title                    | string  | `domain specific` | Title of the domain in a view.                                            |
 


### PR DESCRIPTION
# Documentation Change

Thank you for contributing to the documentation!  
Please fill out the following information to help us review your pull request.

---

## Description of Change

It fixes a typo at `Domain Options`

## Motivation and Context

Word `Weather` is mistaken for the word `Whether`.

## Related Issue(s)

N.A.

---

## Documentation Checklist

Please check off the following tasks that apply to your change:

* [x] I have **reviewed the existing documentation** to ensure my changes are consistent with the current style and
  tone.
* [x] I have checked for and fixed any **broken links** (internal or external).
* [x] I have confirmed that the new/updated content is **technically accurate**.
* [x] I have ensured any **code snippets or examples** are properly formatted and valid.
* [x] I have tested that the documentation **builds and displays correctly** (if applicable, by running the local
  documentation server).

---

## Screenshots / Live Preview (if applicable)

N.A.
