### PR TITLE
Protect dist/ directory from direct commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+if git diff --cached --name-only --diff-filter=ACMR | grep -q '^dist/'; then
+    echo "Error: Direct commits to dist/ are not allowed."
+    echo "These files are managed by CI. Use 'git commit --no-verify' if absolutely necessary."
+    exit 1
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,44 +157,10 @@ You can contribute to this project by following the *fork → clone → edit →
 
 #### Prevent changes to the distribution directory
 
-We must not commit any changes to directory `dist` or its content.
-As a help, you can configure your local git repository to ignore this directory.
+We must not commit any changes to the `dist` directory or its content.
 
-```shell
-git update-index --skip-worktree ./dist/
-git update-index --skip-worktree ./dist/name-of-the-file-to-ignore.js
-```
-
-To revert above, run the following commands:
-
-```shell
-git update-index --no-skip-worktree ./dist/
-git update-index --skip-worktree ./dist/name-of-the-file-to-ignore.js
-```
-
-##### Additional method
-
-You can add the directory to the `exclude` file of the repository.
-However, the directory or its content will not be ignored once it's already tracked.
-The syntax is the same as for the `.gitignore` file.
-
-Example of file `<project-directory>/.git/info/exclude`:
-
-```gitexclude
-# git ls-files --others --exclude-from=.git/info/exclude
-# Lines that start with '#' are comments.
-# For a project mostly in C, the following would be a good set of
-# exclude patterns (uncomment them if you want to use them):
-# *.[oa]
-# *~
-/dist/
-```
-
-Note: If you already have unstaged changes, you must run the following git command after editing your ignore-patterns:
-
-```shell
-git update-index --assume-unchanged ./dist/
-```
+This is enforced by a pre-commit hook that will prevent any commits to the `dist/` directory.
+The hook is automatically set up when you run `npm install`.
 
 ## Style Guides
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mushroom-strategy",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4"
@@ -19,6 +19,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
         "home-assistant-js-websocket": "^9.5.0",
+        "husky": "^9.1.7",
         "markdownlint-cli2": "^0.18.1",
         "prettier": "^3.6.2",
         "semver": "^7.7.3",
@@ -2384,6 +2385,22 @@
       "integrity": "sha512-gCBX0ulIPW3o5EhYxyNKgztBwNIs7u4hypZ+rcWir65wjLKL3b5uDx1jzU7RceyuANxvVKwBVLNujBeFohjnUw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
     "home-assistant-js-websocket": "^9.5.0",
+    "husky": "^9.1.7",
     "markdownlint-cli2": "^0.18.1",
     "prettier": "^3.6.2",
     "semver": "^7.7.3",
@@ -56,6 +57,7 @@
     "md:lint:fix": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#dist\" --fix",
     "build-dev": "webpack --config webpack.dev.config.ts",
     "build": "webpack",
-    "bump": "bump --preid alpha package.json package-lock.json README.md ./docs/index.md ./src/mushroom-strategy.ts"
+    "bump": "bump --preid alpha package.json package-lock.json README.md ./docs/index.md ./src/mushroom-strategy.ts",
+    "prepare": "husky"
   }
 }


### PR DESCRIPTION
# Feature Pull Request

Thank you for contributing to the project!  
Please fill out the following information to help us review your pull request.

---

## Feature Summary

Adds a pre-commit hook to prevent accidental commits to the `dist/` directory, which should only be updated by CI.

---

## Motivation and Context

Prevents developers from directly committing changes to the `dist/` directory. This directory contains the distribution files, which are automatically generated and managed by the CI/CD pipeline.  Accidental commits to this directory can lead to inconsistencies and conflicts.

---

## List of Changes

- Adds a `.husky/pre-commit` script to check for commits to the `dist/` directory.
- Updates `CONTRIBUTING.md` to reflect the change and remove outdated instructions on ignoring the `dist/` directory.
- Adds `husky` as a development dependency.
- Adds `prepare` script to `package.json` to automatically install husky hooks.

## Documentation Updates

Updated `CONTRIBUTING.md` to reflect the enforcement of dist protection using a pre-commit hook. Removed previous instructions related to ignoring the `dist` directory manually, as the hook handles this automatically.

---

## Agreements

Please confirm the following by inserting an `x` between the brackets:

- [x] My code adheres to the [contribution guidelines](blob/main/CONTRIBUTING.md) of the project.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.