### PR TITLE
Fix:  Miscellaneous Card is not showing icon of entity.

### DIFF
--- a/src/cards/MiscellaneousCard.ts
+++ b/src/cards/MiscellaneousCard.ts
@@ -12,7 +12,7 @@ class MiscellaneousCard extends AbstractCard {
   static getDefaultConfig(): EntityCardConfig {
     return {
       type: 'custom:mushroom-entity-card',
-      icon_color: 'blue-grey',
+      icon: undefined,
     };
   }
 


### PR DESCRIPTION
# Bug Fix Pull Request

## Bug Summary

Closes #287 regarding the icon of Miscellaneous Card.

---

## Motivation and Context

Using the Lovelace Mushroom default icons makes the entity type much more recognizable at a glance.

---

## List of Changes

* Removed property `icon_color` so it defaults to the entity's default color, defined by Lovelace Mushroom.
* Added property `icon` to so it defaults to the entity's default icon, defined by Lovelace Mushroom.

