### PR TITLE
Ability to set visibility of 'config'and 'diagnostic' entities per domain.

### DIFF
--- a/docs/full-example.md
+++ b/docs/full-example.md
@@ -26,6 +26,7 @@ strategy:
         order: 1
         stack_count: 2
         title: "My cool lights"
+        hide_diagnostic_entities: false
     badges:
       weather_entity: weather.forecast_home
       climate_count: false

--- a/docs/options/domain-options.md
+++ b/docs/options/domain-options.md
@@ -13,7 +13,7 @@ Mushroom strategy supports several domains to control/view entities of.<br>
 | Fan           | `fan`           |        70         | Speed-controlled or toggle devices specifically for air movement.   |
 | Cover         | `cover`         |        80         | Motorized blinds, curtains, garage doors, or shutters.              |
 | Media Player  | `media_player`  |        90         | Audio and video playback devices like TVs, speakers, and receivers. |
-| Switch        | `switch`        |        100        | Basic toggles (e.g., for outlets or non-dimmable devices.           |
+| Switch        | `switch`        |        100        | Basic toggles (e.g., for outlets or non-dimmable devices).          |
 | Vacuum        | `vacuum`        |        110        | Robotic cleaners with controls for docking and cleaning cycles.     |
 | Valve         | `valve`         |        120        | Controls for gas or water flow, including irrigation systems.       |
 | Select        | `select`        |        130        | Configuration entities allowing a choice from a list of options.    |
@@ -25,15 +25,15 @@ Mushroom strategy supports several domains to control/view entities of.<br>
 The `domains` group enables you to specify the configuration of a domain in a view.<br>
 Each configuration is identified by a domain name and can have the following options:
 
-| Option                   | type    | Default         | Description                                                               |
-|:-------------------------|:--------|:----------------|:--------------------------------------------------------------------------|
-| hidden                   | boolean | `false`         | Set to `true` to exclude the domain from the dashboard.                   |
-| hide_config_entities     | boolean | `true`          | Set to `false` to include config-entities to the dashboard.               |
-| hide_diagnostic_entities | boolean | `true`          | Set to `false` to include diagnostic-entities to the dashboard.           |
-| order                    | number  | `unset`         | Ordering position of the domain entities in a view.                       |
-| show_controls            | boolean | `true`          | Whether to show controls in a view, to switch all entities of the domain. |
-| stack_count              | object  | `{_: 1}`        | Cards per row.[^1]                                                        |
-| title                    | string  | domain specific | Title of the domain in a view.                                            |
+| Option                   | type    | Default             | Description                                                               |
+|:-------------------------|:--------|:--------------------|:--------------------------------------------------------------------------|
+| hidden                   | boolean | `false`             | Set to `true` to exclude the domain from the dashboard.                   |
+| hide_config_entities     | boolean | `true`              | Set to `false` to include config-entities to the dashboard.               |
+| hide_diagnostic_entities | boolean | `true`              | Set to `false` to include diagnostic-entities to the dashboard.           |
+| order                    | number  | `unset`             | Ordering position of the domain entities in a view.                       |
+| show_controls            | boolean | `true`              | Whether to show controls in a view, to switch all entities of the domain. |
+| stack_count              | object  | `1`<br>(set by `_`) | Cards per row.[^1]                                                        |
+| title                    | string  | domain specific     | Title of the domain in a view.                                            |
 
 [^1]:
 In the different views, the cards belonging to a specific domain will be horizontally stacked into a row.<br>

--- a/docs/options/domain-options.md
+++ b/docs/options/domain-options.md
@@ -2,38 +2,38 @@
 
 Mushroom strategy supports several domains to control/view entities of.<br>
 
-| Domain        | Ordering Position | Description                                                         |
-|:--------------|:-----------------:|:--------------------------------------------------------------------|
-| Lock          |        10         | Security devices for locking and unlocking doors or gates.          |
-| Binary Sensor |        20         | On/Off sensors such as motion, door/window contacts, or smoke.      |
-| Camera        |        30         | Video stream entities from doorbells or security cameras.           |
-| Light         |        40         | Light bulbs and LED strips.                                         |
-| Scene         |        50         | Predefined states for a group of entities (e.g., "Movie Night").    |
-| Climate       |        60         | HVAC systems, thermostats, and temperature control units.           |
-| Fan           |        70         | Speed-controlled or toggle devices specifically for air movement.   |
-| Cover         |        80         | Motorized blinds, curtains, garage doors, or shutters.              |
-| Media Player  |        90         | Audio and video playback devices like TVs, speakers, and receivers. |
-| Switch        |        100        | Basic toggles (e.g., for outlets or non-dimmable devices.           |
-| Vacuum        |        110        | Robotic cleaners with controls for docking and cleaning cycles.     |
-| Valve         |        120        | Controls for gas or water flow, including irrigation systems.       |
-| Select        |        130        | Configuration entities allowing a choice from a list of options.    |
-| Input Select  |        140        | Helper entities for choosing options within the UI or automations.  |
-| Number        |        150        | Entities representing a numerical value with a specific range.      |
-| Sensor        |        160        | State entities for data like temperature, humidity, or power usage. |
-| Other         |        170        | Any other domain not explicitly categorized above.                  |
+| Domain        | name            | Ordering Position | Description                                                         |
+|:--------------|:----------------|:-----------------:|:--------------------------------------------------------------------|
+| Lock          | `lock`          |        10         | Security devices for locking and unlocking doors or gates.          |
+| Binary Sensor | `binary_sensor` |        20         | On/Off sensors such as motion, door/window contacts, or smoke.      |
+| Camera        | `camera`        |        30         | Video stream entities from doorbells or security cameras.           |
+| Light         | `light`         |        40         | Light bulbs and LED strips.                                         |
+| Scene         | `scene`         |        50         | Predefined states for a group of entities (e.g., "Movie Night").    |
+| Climate       | `climate`       |        60         | HVAC systems, thermostats, and temperature control units.           |
+| Fan           | `fan`           |        70         | Speed-controlled or toggle devices specifically for air movement.   |
+| Cover         | `cover`         |        80         | Motorized blinds, curtains, garage doors, or shutters.              |
+| Media Player  | `media_player`  |        90         | Audio and video playback devices like TVs, speakers, and receivers. |
+| Switch        | `switch`        |        100        | Basic toggles (e.g., for outlets or non-dimmable devices.           |
+| Vacuum        | `vacuum`        |        110        | Robotic cleaners with controls for docking and cleaning cycles.     |
+| Valve         | `valve`         |        120        | Controls for gas or water flow, including irrigation systems.       |
+| Select        | `select`        |        130        | Configuration entities allowing a choice from a list of options.    |
+| Input Select  | `input_select`  |        140        | Helper entities for choosing options within the UI or automations.  |
+| Number        | `number`        |        150        | Entities representing a numerical value with a specific range.      |
+| Sensor        | `sensor`        |        160        | State entities for data like temperature, humidity, or power usage. |
+| Other         | `default`       |        170        | Any other domain not explicitly categorized above.                  |
 
 The `domains` group enables you to specify the configuration of a domain in a view.<br>
 Each configuration is identified by a domain name and can have the following options:
 
-| Option                   | type    | Default           | Description                                                               |
-|:-------------------------|:--------|:------------------|:--------------------------------------------------------------------------|
-| hidden                   | boolean | `false`           | Set to `true` to exclude the domain from the dashboard.                   |
-| hide_config_entities     | boolean | `true`            | Set to `false` to include config-entities to the dashboard.               |
-| hide_diagnostic_entities | boolean | `true`            | Set to `false` to include diagnostic-entities to the dashboard.           |
-| order                    | number  | `unset`           | Ordering position of the domain entities in a view.                       |
-| show_controls            | boolean | `true`            | Whether to show controls in a view, to switch all entities of the domain. |
-| stack_count              | object  | `{_: 1}`          | Cards per row.[^1]                                                        |
-| title                    | string  | `domain specific` | Title of the domain in a view.                                            |
+| Option                   | type    | Default         | Description                                                               |
+|:-------------------------|:--------|:----------------|:--------------------------------------------------------------------------|
+| hidden                   | boolean | `false`         | Set to `true` to exclude the domain from the dashboard.                   |
+| hide_config_entities     | boolean | `true`          | Set to `false` to include config-entities to the dashboard.               |
+| hide_diagnostic_entities | boolean | `true`          | Set to `false` to include diagnostic-entities to the dashboard.           |
+| order                    | number  | `unset`         | Ordering position of the domain entities in a view.                       |
+| show_controls            | boolean | `true`          | Whether to show controls in a view, to switch all entities of the domain. |
+| stack_count              | object  | `{_: 1}`        | Cards per row.[^1]                                                        |
+| title                    | string  | domain specific | Title of the domain in a view.                                            |
 
 [^1]:
 In the different views, the cards belonging to a specific domain will be horizontally stacked into a row.<br>
@@ -42,8 +42,7 @@ The number of cards per row can be configured with this option.
 !!! note
 
     * Domain `default` represents any other domain than supported by this strategy.
-    * The `show_controls` option will default to false for domain which can't be controlled.
-    * The `hide_config_entities` and `hide_diagnostic_entities` options are only available as an "All domains" option.
+    * The `show_controls` option will default to false for domains that can't be controlled.
 
 ## Sorting Domains
 
@@ -55,7 +54,8 @@ To make the most of this, it helps to understand how the system prioritizes your
   This allows you to "pin" your most-used domains—like lights or fans—so they are always the first things you
   see.
 - If two domains share the same order value, the system will use their names to determine which one comes first.
-- Any domain without an order property will be placed after/below your prioritized list, sorted alphabetically by name.
+- Domains missing an `order` property or set to `undefined` will follow your prioritized list, sorted alphabetically by
+  name.
 
 ## Setting options for all domains
 
@@ -77,6 +77,7 @@ strategy:
       switch:
         stack_count: 3
         show_controls: false
+        hide_diagnostic_entities: false
       default: # All other domains
         hidden: true
 ```

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -137,10 +137,6 @@ class Registry {
 
     // Process entries of the HASS entity registry.
     Registry._entities = new RegistryFilter(Registry.entities)
-      .not()
-      .whereEntityCategory('config')
-      .not()
-      .whereEntityCategory('diagnostic')
       .isNotHidden()
       .whereDisabledBy(null)
       .toList()

--- a/src/configurationDefaults.ts
+++ b/src/configurationDefaults.ts
@@ -40,8 +40,8 @@ export const ConfigurationDefaults: StrategyDefaults = {
   debug: false,
   domains: {
     _: {
-      hide_config_entities: undefined,
-      hide_diagnostic_entities: undefined,
+      hide_config_entities: true,
+      hide_diagnostic_entities: true,
       show_controls: true,
       stack_count: 1,
     },

--- a/src/mushroom-strategy.ts
+++ b/src/mushroom-strategy.ts
@@ -124,9 +124,15 @@ class MushroomStrategy extends HTMLTemplateElement {
     // Prepare promises for all supported domains
     const domainCardPromises = exposedDomainNames.filter(isSupportedDomain).map(async (domain) => {
       const moduleName = sanitizeClassName(domain + 'Card');
+      const domainOptions = {
+        ...Registry.strategyOptions.domains['_'],
+        ...Registry.strategyOptions.domains[domain],
+      };
 
       const entities = new RegistryFilter(areaEntities)
         .whereDomain(domain)
+        .when(domainOptions.hide_config_entities, (filter) => filter.not().whereEntityCategory('config'))
+        .when(domainOptions.hide_diagnostic_entities, (filter) => filter.not().whereEntityCategory('diagnostic'))
         .where((entity) => !(domain === 'switch' && entity.entity_id.endsWith('_stateful_scene')))
         .toList();
 
@@ -136,10 +142,7 @@ class MushroomStrategy extends HTMLTemplateElement {
 
       const headerCard = new HeaderCard(
         { entity_id: entities.map((entity) => entity.entity_id) },
-        {
-          ...Registry.strategyOptions.domains['_'],
-          ...Registry.strategyOptions.domains[domain],
-        }
+        domainOptions
       ).createCard();
 
       try {

--- a/src/mushroom-strategy.ts
+++ b/src/mushroom-strategy.ts
@@ -24,8 +24,8 @@ import { NOTIFICATIONS } from './notifications';
 import MiscellaneousCard from './cards/MiscellaneousCard';
 
 /**
- * Mushroom Dashboard Strategy.<br>
- * <br>
+ * Mushroom Dashboard Strategy.
+ *
  * Mushroom dashboard strategy provides a strategy for Home-Assistant to create a dashboard automatically.<br>
  * The strategy makes use Mushroom and Mini Graph cards to represent your entities.
  *

--- a/src/types/strategy/strategy-generics.ts
+++ b/src/types/strategy/strategy-generics.ts
@@ -175,16 +175,16 @@ export interface ViewInfo {
 /**
  * All-Domains Configuration.
  *
- * @property {boolean} [hide_config_entities] - If True, all configuration entities are hidden from the dashboard.
- * @property {boolean} [hide_diagnostic_entities] - If True, all diagnostic entities are hidden from the dashboard.
- * @property {boolean} [show_controls] - False to hide controls.
- * @property {number} [stack_count] - Number of cards per row.
+ * @property {boolean} hide_config_entities - If True, all configuration entities are hidden from the dashboard.
+ * @property {boolean} hide_diagnostic_entities - If True, all diagnostic entities are hidden from the dashboard.
+ * @property {boolean} show_controls - False to hide controls.
+ * @property {number} stack_count - Number of cards per row.
  */
 export interface AllDomainsConfig {
-  hide_config_entities?: boolean;
-  hide_diagnostic_entities?: boolean;
-  show_controls?: boolean;
-  stack_count?: number;
+  hide_config_entities: boolean;
+  hide_diagnostic_entities: boolean;
+  show_controls: boolean;
+  stack_count: number;
 }
 
 /**

--- a/src/utilities/RegistryFilter.ts
+++ b/src/utilities/RegistryFilter.ts
@@ -293,29 +293,9 @@ class RegistryFilter<T extends RegistryEntry, K extends keyof T = keyof T> {
   }
 
   /**
-   * Filters entries **strictly** by their `entity_category`.
+   * Filters entries strictly by their `entity_category`.
    *
-   * - Without `.not()`: returns only entries where `entity_category` exactly matches the given argument (e.g.,
-   *   'config', 'diagnostic', null, or undefined).
-   * - With `.not()`: returns all entries where `entity_category` does NOT match the given argument.
-   *
-   * @param {EntityCategory | null} entityCategory The desired entity_category (e.g., 'config', 'diagnostic', null, or
-   *   undefined)
-   *
-   * @remarks
-   * Visibility via the strategy options:
-   * - If `hide_{category}_entities: true` is set, entries of that category are NEVER kept, regardless of the filter.
-   * - If `hide_{category}_entities: false` is set, entries of that category are ALWAYS kept when filtering for that
-   *   category, even when preceded by `.not()`.
-   * - If neither is set:
-   *   - If preceded by not(), entries of that category are implicitly filtered out.
-   *   - Otherwise they are implicitly kept.
-   *
-   * @example
-   *  .whereEntityCategory('config')           // Only 'config' entries (unless explicitly hidden)
-   *  .not().whereEntityCategory('diagnostic') // All except 'diagnostic' entries
-   *  .whereEntityCategory(null)               // Only entries with 'entity_category: null'
-   *  .whereEntityCategory()                   // Only entries without an 'entity_category' field
+   * @param {EntityCategory | null} entityCategory The desired entity_category (e.g., 'config', 'diagnostic', or null).
    */
   whereEntityCategory(entityCategory?: EntityCategory | null): this {
     const invert = this.invertNext;
@@ -323,18 +303,6 @@ class RegistryFilter<T extends RegistryEntry, K extends keyof T = keyof T> {
 
     const predicate = (entry: T) => {
       const category = 'entity_category' in entry ? entry.entity_category : undefined;
-      const hideOption =
-        typeof category === 'string'
-          ? Registry.strategyOptions?.domains?.['_']?.[`hide_${category}_entities`]
-          : undefined;
-
-      if (hideOption === true) {
-        return false;
-      }
-
-      if (hideOption === false && category === entityCategory) {
-        return true;
-      }
 
       return invert ? category !== entityCategory : category === entityCategory;
     };

--- a/src/utilities/RegistryFilter.ts
+++ b/src/utilities/RegistryFilter.ts
@@ -69,6 +69,19 @@ class RegistryFilter<T extends RegistryEntry, K extends keyof T = keyof T> {
   }
 
   /**
+   * Applies a set of filters only if a condition is met.
+   *
+   * @param {boolean} condition The condition to check.
+   * @param {(filter: this) => this} callback A function that receives the filter instance and applies more filters.
+   */
+  when(condition: boolean, callback: (filter: this) => this): this {
+    if (condition) {
+      return callback(this);
+    }
+    return this;
+  }
+
+  /**
    * Filters entries by their `area_id`.
    *
    * @param {string|null} [areaId] - The area id to match.


### PR DESCRIPTION
## Feature Summary

Add the ability to set visibility of 'config' and 'diagnostic' types per domain.

---

## Motivation and Context

Currently you can only set the visibility for all of the domains with the `_` key.

Because of this limitation, the user is not able to only include these kind of entities he's interested in. E.g., Battery Sensors.

Closes #305 

---

## List of Changes

- Add `when` method to RegistryFilter.
- Cut hideOption logic from predicate of `whereEntityCategory` filter.
- Refactor entity filtering.
- Refactor domain options documentation.

- ...

## Documentation Updates

See commit 438cf1c0

---

## Agreements

Please confirm the following by inserting an `x` between the brackets:

- [x] My code adheres to the [contribution guidelines](blob/main/CONTRIBUTING.md) of the project.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
