### PR TITLE
Feature: Assign an order value to each area

### DIFF
--- a/docs/full-example.md
+++ b/docs/full-example.md
@@ -4,9 +4,10 @@
 strategy:
   type: custom:mushroom-strategy
   options:
+    show_positions: true
     views:
       light:
-        order: 1
+        order: 10
         title: illumination
       switches:
         hidden: true
@@ -23,7 +24,7 @@ strategy:
         hide_config_entities: true
         stack_count: 1
       light:
-        order: 1
+        order: 10
         stack_count: 2
         title: "My cool lights"
         hide_diagnostic_entities: false
@@ -62,7 +63,7 @@ strategy:
         name: Kitchen
         icon: mdi:silverware-fork-knife
         icon_color: red
-        order: 1
+        order: 10
       master_bedroom_id:
         name: Master Bedroom
         icon: mdi:bed-king

--- a/docs/options/area-options.md
+++ b/docs/options/area-options.md
@@ -3,13 +3,13 @@
 The `areas` group enables you to specify the configuration of specific areas.<br>
 Each configuration is identified by an area id and can have the following options:
 
-| Name          | Type           | Default         | Description                                                                |
-|:--------------|:---------------|:----------------|:---------------------------------------------------------------------------|
-| `extra_cards` | array of cards | `[]`            | A list of cards to show on the top of the area sub-view.                   |
-| `hidden`      | boolean        | `false`         | Set to `true` to exclude the area from the dashboard and views.            |
-| `name`        | string         | `Area specific` | The name of the area.                                                      |
-| `order`       | number         | `unset`         | Ordering position of the area in the list of available areas.              |
-| `type`        | string         | `default`       | Set to a type of area card. (Currently supported: `default` & `HaAreaCard` |
+| Name          | Type           | Default       | Description                                                                |
+|:--------------|:---------------|:--------------|:---------------------------------------------------------------------------|
+| `extra_cards` | array of cards | `[]`          | A list of cards to show on the top of the area sub-view.                   |
+| `hidden`      | boolean        | `false`       | Set to `true` to exclude the area from the dashboard and views.            |
+| `name`        | string         | Area specific | The name of the area.                                                      |
+| `order`       | number         | Area specific | Ordering position of the area in the list of available areas.              |
+| `type`        | string         | `default`     | Set to a type of area card. (Currently supported: `default` & `HaAreaCard` |
 
 Also, all options from the Template mushroom card and/or Home Assistant Area card are supported.<br>
 Please follow the links below to see the additional options per card type.
@@ -21,13 +21,18 @@ Please follow the links below to see the additional options per card type.
 
 The `order` property gives you control over how your areas are arranged in a view.
 
-To make the most of this, it helps to understand how the system prioritizes your list:
+To make the most of this, it helps to understand how the strategy prioritizes your list:
 
-- Any area assigned an order value will automatically move to the front/top.<br>
-  This allows you to "pin" your most-used rooms—like the Kitchen or Living Room—so they are always the first things you
-  see.
-- If two areas share the same order value, the system will use their names to determine which one comes first.
-- Any areas without an order property will be placed after/below your prioritized list, sorted alphabetically by name.
+- Each area is assigned an `order` value that corresponds to its position in the alphabetically sorted list.<br>
+  For example, if you have three areas named "Bedroom", "Kitchen", and "Living Room", they would be assigned `order` 
+  values of 10, 20, and 30 respectively.
+- Setting this value in the configuration allows you to "pin" your most-used rooms—like the Kitchen or Living Room—so
+  they are always the first things you see.
+- If two areas share the same order value, the strategy will use their names to determine which one comes first.
+- Areas missing the `order` property (or set to `undefined`) will follow your prioritized list, sorted alphabetically by
+  name.
+- By default, the strategy assigns the highest possible `order` value to the undisclosed area, ensuring it appears last
+  in the list.
 
 ## Extra Cards
 

--- a/docs/options/area-options.md
+++ b/docs/options/area-options.md
@@ -19,20 +19,22 @@ Please follow the links below to see the additional options per card type.
 
 ## Sorting Areas
 
-The `order` property gives you control over how your areas are arranged in a view.
+The `order` property gives you control over how areas are arranged in a view.
 
-To make the most of this, it helps to understand how the strategy prioritizes your list:
+To make the most of this, it helps to understand how the strategy prioritizes these elements, as explained in chapter
+[Element Positioning](index.md#element-positioning).
 
-- Each area is assigned an `order` value that corresponds to its position in the alphabetically sorted list.<br>
-  For example, if you have three areas named "Bedroom", "Kitchen", and "Living Room", they would be assigned `order` 
-  values of 10, 20, and 30 respectively.
-- Setting this value in the configuration allows you to "pin" your most-used rooms—like the Kitchen or Living Room—so
-  they are always the first things you see.
-- If two areas share the same order value, the strategy will use their names to determine which one comes first.
-- Areas missing the `order` property (or set to `undefined`) will follow your prioritized list, sorted alphabetically by
-  name.
-- By default, the strategy assigns the highest possible `order` value to the undisclosed area, ensuring it appears last
-  in the list.
+Possible values for `order` are:
+
+- Any number, with lower values appearing first. For example, an area with `order: 10` will appear before an area with
+  `order: 20`.
+- `undefined` or missing `order` property, which will follow your prioritized list, sorted alphabetically by name.
+- `Infinity` or `-Infinity` to always show an area last or first, respectively.
+
+!!! note
+
+    By default, the strategy assigns the highest possible `order` value to the [undisclosed](#undisclosed-area) area,
+    ensuring it appears last in the list.
 
 ## Extra Cards
 
@@ -47,12 +49,13 @@ See Home View Options → [Extra Cards](#extra-cards) for more information.
 strategy:
   type: custom:mushroom-strategy
   options:
+    show_positions: true
     areas:
       family_room_id:
         name: Family Room
         icon: mdi:television
         icon_color: green
-        order: 1
+        order: 10
         extra_cards:
           - type: custom:mushroom-chips-card
             chips:
@@ -65,7 +68,7 @@ strategy:
         name: Kitchen
         icon: mdi:silverware-fork-knife
         icon_color: red
-        order: 2
+        order: 20
       garage_id:
         hidden: true
       hallway_id:

--- a/docs/options/domain-options.md
+++ b/docs/options/domain-options.md
@@ -25,15 +25,15 @@ Mushroom strategy supports several domains to control/view entities of.<br>
 The `domains` group enables you to specify the configuration of a domain in a view.<br>
 Each configuration is identified by a domain name and can have the following options:
 
-| Option                   | type    | Default             | Description                                                               |
-|:-------------------------|:--------|:--------------------|:--------------------------------------------------------------------------|
-| hidden                   | boolean | `false`             | Set to `true` to exclude the domain from the dashboard.                   |
-| hide_config_entities     | boolean | `true`              | Set to `false` to include config-entities to the dashboard.               |
-| hide_diagnostic_entities | boolean | `true`              | Set to `false` to include diagnostic-entities to the dashboard.           |
-| order                    | number  | `unset`             | Ordering position of the domain entities in a view.                       |
-| show_controls            | boolean | `true`              | Whether to show controls in a view, to switch all entities of the domain. |
-| stack_count              | object  | `1`<br>(set by `_`) | Cards per row.[^1]                                                        |
-| title                    | string  | domain specific     | Title of the domain in a view.                                            |
+| Option                     | type    | Default             | Description                                                               |
+|:---------------------------|:--------|:--------------------|:--------------------------------------------------------------------------|
+| `hidden`                   | boolean | `false`             | Set to `true` to exclude the domain from the dashboard.                   |
+| `hide_config_entities`     | boolean | `true`              | Set to `false` to include config-entities to the dashboard.               |
+| `hide_diagnostic_entities` | boolean | `true`              | Set to `false` to include diagnostic-entities to the dashboard.           |
+| `order`                    | number  | domain specific     | Ordering position of the domain entities in a view.                       |
+| `show_controls`            | boolean | `true`              | Whether to show controls in a view, to switch all entities of the domain. |
+| `stack_count`              | object  | `1`<br>(set by `_`) | Cards per row.[^1]                                                        |
+| `title`                    | string  | domain specific     | Title of the domain in a view.                                            |
 
 [^1]:
 In the different views, the cards belonging to a specific domain will be horizontally stacked into a row.<br>
@@ -46,16 +46,21 @@ The number of cards per row can be configured with this option.
 
 ## Sorting Domains
 
-The `order` property gives you control over how the domains are arranged in a view.
+The `order` property gives you control over how domains are arranged in a view.
 
-To make the most of this, it helps to understand how the system prioritizes your list:
+To make the most of this, it helps to understand how the strategy prioritizes these elements, as explained in chapter
+[Element Positioning](index.md#element-positioning).
 
-- Any domain assigned an order value will automatically move to the front/top.<br>
-  This allows you to "pin" your most-used domains—like lights or fans—so they are always the first things you
-  see.
-- If two domains share the same order value, the system will use their names to determine which one comes first.
-- Domains missing an `order` property or set to `undefined` will follow your prioritized list, sorted alphabetically by
-  name.
+Possible values for `order` are:
+
+- Any number, with lower values appearing first. For example, a domain with `order: 10` will appear before domian with
+  `order: 20`.
+- `undefined` or missing `order` property, which will follow your prioritized list, sorted alphabetically by name.
+- `Infinity` or `-Infinity` to always show a domain last or first, respectively.
+
+!!! note
+
+    Keep in mind that the domains have a default order as shown in the table above.
 
 ## Setting options for all domains
 
@@ -67,17 +72,19 @@ Use `_` as the identifier to set options for all domains.
 strategy:
   type: custom:mushroom-strategy
   options:
+    show_positions: true
     domains:
       _:
         stack_count: 2
         hide_config_entities: false
       light:
         title: "My cool lights"
-        order: 1
+        order: 10
       switch:
         stack_count: 3
         show_controls: false
         hide_diagnostic_entities: false
+        order: 20
       default: # All other domains
         hidden: true
 ```

--- a/docs/options/index.md
+++ b/docs/options/index.md
@@ -19,17 +19,39 @@ By default,
 
 The options are divided into groups as described below.
 
-| Name               | Type           | Default               | Description                                                                                                                               |
-|:-------------------|:---------------|:----------------------|:------------------------------------------------------------------------------------------------------------------------------------------|
-| areas              | object         | undisclosed           | See [Area Options](area-options.md).                                                                                                      |
-| card_options       | object         | empty                 | See [Card Options](card-options.md).                                                                                                      |
-| domains            | object         | All supported domains | See [Domain Options](domain-options.md).                                                                                                  |
-| home_view          | object         | unset                 | See [Home View Options](home-view-options.md).                                                                                            |
-| badges             | object         | All supported badges  | See [Badge Options](home-view-options.md#badge-options).                                                                                  |
-| quick_access_cards | array of cards | empty                 | List of cards to show between the greeting card and the area cards.<br>See [Quick Access Cards](home-view-options.md#quick-access-cards). |
-| extra_cards        | array of cards | empty                 | List of cards to show below the area cards.<br>See [extra Cards](home-view-options.md#extra-cards).                                       |
-| views              | object         | All supported views   | See [View Options](view-options.md).                                                                                                      |
-| extra_views        | array of views | empty                 | List of user defined views to add to the dashboard.<br>See [Extra Views](view-options.md#extra-views).                                    |
+| Name                 | Type           | Default               | Description                                                                                                                               |
+|:---------------------|:---------------|:----------------------|:------------------------------------------------------------------------------------------------------------------------------------------|
+| `show_positions`     | bool           | false                 | Toggles the visibility of positioned elements (Area, View, Domain).                                                                       |
+| `areas`              | object         | {undisclosed}         | See [Area Options](area-options.md).                                                                                                      |
+| `card_options`       | object         | empty                 | See [Card Options](card-options.md).                                                                                                      |
+| `domains`            | object         | All supported domains | See [Domain Options](domain-options.md).                                                                                                  |
+| `home_view`          | object         | unset                 | See [Home View Options](home-view-options.md).                                                                                            |
+| `badges`             | object         | All supported badges  | See [Badge Options](home-view-options.md#badge-options).                                                                                  |
+| `quick_access_cards` | array of cards | empty                 | List of cards to show between the greeting card and the area cards.<br>See [Quick Access Cards](home-view-options.md#quick-access-cards). |
+| `extra_cards`        | array of cards | empty                 | List of cards to show below the area cards.<br>See [extra Cards](home-view-options.md#extra-cards).                                       |
+| `views`              | object         | All supported views   | See [View Options](view-options.md).                                                                                                      |
+| `extra_views`        | array of views | empty                 | List of user defined views to add to the dashboard.<br>See [Extra Views](view-options.md#extra-views).                                    |
+
+## Global Options
+
+### Element Positioning
+
+Elements like **Areas**, **Views**, and **Domains** are automatically assigned an `order` value based on their position
+in their respective alphabetically sorted list. This value gives you control over how those elements are arranged in the
+dashboard, with lower values appearing first.
+
+To make the most of this, it helps to understand how the strategy prioritizes a sorted list:
+
+- Each element is assigned an `order` value that corresponds to its position in the alphabetically sorted list.<br>
+  For example, if you have three areas named "Bedroom", "Kitchen", and "Living Room", they would be assigned `order`
+  values of 10, 20, and 30 respectively.
+- Setting this value in the configuration allows you to "pin" your most-used elements in between others.
+- If two elements share the same order value, the strategy will use their names to determine which one comes first.
+- Elements missing the `order` property (or set to `undefined`) will follow the prioritized list, sorted alphabetically
+  by name.
+
+The visibility of the ordering positions can be toggled with the `show_positions` option<br>
+This can be helpful when you have a long list and want to quickly identify their order values.
 
 ## Example
 
@@ -37,9 +59,16 @@ The options are divided into groups as described below.
 strategy:
   type: custom:mushroom-strategy
   options:
+    show_positions: true
     areas:
       family_room_id:
         name: Family Room
         icon: mdi:sofa
         icon_color: green
+        order: 10
+      kitchen_id:
+        name: Kitchen
+        icon: mdi:fridge
+        icon_color: blue
+        order: 20
 ```

--- a/docs/options/view-options.md
+++ b/docs/options/view-options.md
@@ -5,62 +5,68 @@ Hidden/Disabled entities or linked to a hidden area are excluded from the view.
 
 The following views are supported and enabled by default:
 
-| View    | Ordering Position | Type   | Description               |
-|:--------|:-----------------:|:-------|:--------------------------|
-| home    |        10         | object | The strategy's Home View. |
-| light   |        20         | object | View to control lights.   |
-| fan     |        30         | object | View to control fans.     |
-| cover   |        40         | object | View to control covers.   |
-| switch  |        50         | object | View to control switches. |
-| climate |        60         | object | View to control climates. |
-| camera  |        70         | object | View to control cameras.  |
-| vacuum  |        80         | object | View to control vacuums.  |
-| scene   |        90         | object | View to control scenes.   |
-| lock    |        100        | object | View to control locks.    |
-| valve   |        110        | object | View to control valves.   |
+| View      | name     | Ordering Position | Type   | Description               |
+|:----------|:---------|:-----------------:|:-------|:--------------------------|
+| `home`    | Home     |        10         | object | The strategy's Home View. |
+| `light`   | Lights   |        20         | object | View to control lights.   |
+| `fan`     | Fans     |        30         | object | View to control fans.     |
+| `cover`   | Covers   |        40         | object | View to control covers.   |
+| `switch`  | Switches |        50         | object | View to control switches. |
+| `climate` | Climates |        60         | object | View to control climates. |
+| `camera`  | Cameras  |        70         | object | View to control cameras.  |
+| `vacuum`  | Vacuums  |        80         | object | View to control vacuums.  |
+| `scene`   | Scenes   |        90         | object | View to control scenes.   |
+| `lock`    | Locks    |        100        | object | View to control locks.    |
+| `valve`   | Valves   |        110        | object | View to control valves.   |
 
 The `views` group enables you to specify the configuration of a view.
 Each configuration is identified by a view name and can have the following options:
 
-| name   | type    | Default                              | description                                                                                    |
-|:-------|:--------|:-------------------------------------|:-----------------------------------------------------------------------------------------------|
-| hidden | boolean | `false`                              | Set to `true` to exclude the view from the dashboard                                           |
-| icon   | string  | domain specific                      | Icon of the view in the navigation bar.                                                        |
-| order  | number  | domain specific<br>(See table above) | Ordering position of the view in the navigation bar.                                           |
-| title  | string  | domain specific                      | Title of the view in the navigation bar. (Shown when no icon is defined or hovering above it.) |
+| name     | type    | Default                              | description                                                                                    |
+|:---------|:--------|:-------------------------------------|:-----------------------------------------------------------------------------------------------|
+| `hidden` | boolean | `false`                              | Set to `true` to exclude the view from the dashboard                                           |
+| `icon`   | string  | domain specific                      | Icon of the view in the navigation bar.                                                        |
+| `order`  | number  | domain specific<br>(See table above) | Ordering position of the view in the navigation bar.                                           |
+| `title`  | string  | domain specific                      | Title of the view in the navigation bar. (Shown when no icon is defined or hovering above it.) |
 
+## Sorting Views
+
+The `order` property gives you control over how views are arranged in the top of the dashboard.
+
+To make the most of this, it helps to understand how the strategy prioritizes these elements, as explained in chapter
+[Element Positioning](index.md#element-positioning).
+
+Possible values for `order` are:
+
+- Any number, with lower values appearing first. For example, a view with `order: 10` will appear before an area with
+  `order: 20`.
+- `undefined` or missing `order` property, which will follow your prioritized list, sorted alphabetically by name.
+- `Infinity` or `-Infinity` to always show a view last or first, respectively.
+
+!!! note
+
+    Keep in mind that the build-in views have a default order as shown in the table above.
+    
 ## Example
 
 ```yaml
 strategy:
   type: custom:mushroom-strategy
+  show_positions: true
   options:
     views:
       light:
-        order: 0
+        order: 10
         title: illumination
       switch:
-        order: 1
+        order: 20
         hidden: true
         icon: mdi:toggle-switch
+      fan:
+        order: 30
+        icon: mdi:fan
 views: []
 ```
-
-## Sorting Views
-
-The `order` property gives you control over how the views are arranged.
-
-To make the most of this, it helps to understand how the system prioritizes your list:
-
-- Any view assigned an order value will automatically move to the front/top.<br>
-  This allows you to "pin" your most-used views—like the Lights or Fans—so they are always the first things you
-  see.
-- If two views share the same order value, the system will use their names to determine which one comes first.
-- Any views without an order property will be placed after/below your prioritized list, sorted alphabetically by name.
-
-!!! note
-
-    Keep in mind that the build-in views have a default order as shown in the table above.
 
 ## Extra Views
 

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -159,18 +159,16 @@ class Registry {
       .map((device) => ({ ...device, area_id: device.area_id ?? 'undisclosed' }));
 
     // Process entries of the HASS area registry.
-    const areaList = [...Registry._areas];
+    const areaList = new RegistryFilter(Registry._areas).orderBy(['name'], 'asc').toList();
 
-    // Add the undisclosed area, if not hidden in the strategy options.
-    if (!Registry.strategyOptions.areas.undisclosed?.hidden) {
-      areaList.push(ConfigurationDefaults.areas.undisclosed);
-    }
+    areaList.push(ConfigurationDefaults.areas.undisclosed);
 
-    Registry._areas = areaList.map((area) => {
+    Registry._areas = areaList.map((area, index) => {
       const isUndisclosed = area.area_id === 'undisclosed';
 
       return {
         ...area,
+        order: (index + 1) * 10,
         ...Registry.strategyOptions.areas._, // Global defaults
         ...Registry.strategyOptions.areas[area.area_id], // Specific overrides
         ...(isUndisclosed ? { area_id: 'undisclosed', type: 'default' } : {}), // Force constraints for undisclosed

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -159,9 +159,9 @@ class Registry {
       .map((device) => ({ ...device, area_id: device.area_id ?? 'undisclosed' }));
 
     // Process entries of the HASS area registry.
-    const areaList = new RegistryFilter(Registry._areas).orderBy(['name'], 'asc').toList();
+    Registry._areas.push(ConfigurationDefaults.areas.undisclosed);
 
-    areaList.push(ConfigurationDefaults.areas.undisclosed);
+    const areaList = new RegistryFilter(Registry._areas).isNotHidden().orderBy(['name'], 'asc').toList();
 
     Registry._areas = areaList.map((area, index) => {
       const isUndisclosed = area.area_id === 'undisclosed';
@@ -176,7 +176,7 @@ class Registry {
     });
 
     // Remove hidden areas if configured as so and sort them by order first, then by name.
-    Registry._areas = new RegistryFilter(Registry._areas).isNotHidden().orderBy(['order', 'name'], 'asc').toList();
+    Registry._areas = new RegistryFilter(Registry._areas).orderBy(['order', 'name'], 'asc').toList();
 
     // Sort views and domains by order first and then by title.
     Registry.strategyOptions.views = Registry.sortConfigByOrder(Registry.strategyOptions.views);

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -175,7 +175,7 @@ class Registry {
       };
     });
 
-    // Remove hidden areas if configured as so and sort them by order first, then by name.
+    // Sort the areas by order first, then by name.
     Registry._areas = new RegistryFilter(Registry._areas).orderBy(['order', 'name'], 'asc').toList();
 
     // Sort views and domains by order first and then by title.

--- a/src/cards/AreaCard.ts
+++ b/src/cards/AreaCard.ts
@@ -1,6 +1,8 @@
-import { AreaRegistryEntry } from '../types/homeassistant/data/area_registry';
 import { TemplateCardConfig } from '../types/lovelace-mushroom/cards/template-card-config';
 import AbstractCard from './AbstractCard';
+import { Registry } from '../Registry';
+import { StrategyArea } from '../types/strategy/strategy-generics';
+import { localize } from '../utilities/localize';
 
 /**
  * Area Card Class
@@ -23,10 +25,10 @@ class AreaCard extends AbstractCard {
   /**
    * Class constructor.
    *
-   * @param {AreaRegistryEntry} area The HASS area to create a card configuration for.
+   * @param {StrategyArea} area The HASS area to create a card configuration for.
    * @param {TemplateCardConfig} [customConfiguration] Custom card configuration.
    */
-  constructor(area: AreaRegistryEntry, customConfiguration?: TemplateCardConfig) {
+  constructor(area: StrategyArea, customConfiguration?: TemplateCardConfig) {
     super(area);
 
     const configuration = AreaCard.getDefaultConfig();
@@ -35,6 +37,10 @@ class AreaCard extends AbstractCard {
 
     configuration.primary = area.name;
     configuration.icon = area.icon || configuration.icon;
+
+    if (Registry.strategyOptions.show_positions) {
+      configuration.secondary = `${localize('generic.ordering_position')}: ${area.order}`;
+    }
 
     if (configuration.tap_action && 'navigation_path' in configuration.tap_action) {
       configuration.tap_action.navigation_path = area.area_id;

--- a/src/cards/HaAreaCard.ts
+++ b/src/cards/HaAreaCard.ts
@@ -1,11 +1,10 @@
 // noinspection JSUnusedGlobalSymbols Class is dynamically imported.
 
-import { AreaRegistryEntry } from '../types/homeassistant/data/area_registry';
 import { AreaCardConfig } from '../types/homeassistant/panels/lovelace/cards/types';
 import AbstractCard from './AbstractCard';
 import { StrategyArea } from '../types/strategy/strategy-generics';
-import { Registry } from "../Registry";
-import { localize } from "../utilities/localize";
+import { Registry } from '../Registry';
+import { localize } from '../utilities/localize';
 
 /**
  * HA Area Card Class

--- a/src/cards/HaAreaCard.ts
+++ b/src/cards/HaAreaCard.ts
@@ -3,6 +3,9 @@
 import { AreaRegistryEntry } from '../types/homeassistant/data/area_registry';
 import { AreaCardConfig } from '../types/homeassistant/panels/lovelace/cards/types';
 import AbstractCard from './AbstractCard';
+import { StrategyArea } from '../types/strategy/strategy-generics';
+import { Registry } from "../Registry";
+import { localize } from "../utilities/localize";
 
 /**
  * HA Area Card Class
@@ -21,10 +24,10 @@ class AreaCard extends AbstractCard {
   /**
    * Class constructor.
    *
-   * @param {AreaRegistryEntry} area The HASS entity to create a card configuration for.
+   * @param {StrategyArea} area The HASS entity to create a card configuration for.
    * @param {AreaCardConfig} [customConfiguration] Custom card configuration.
    */
-  constructor(area: AreaRegistryEntry, customConfiguration?: AreaCardConfig) {
+  constructor(area: StrategyArea, customConfiguration?: AreaCardConfig) {
     super(area);
 
     // Initialize the default configuration.
@@ -32,6 +35,10 @@ class AreaCard extends AbstractCard {
 
     configuration.area = area.area_id;
     configuration.navigation_path = configuration.area;
+
+    if (Registry.strategyOptions.show_positions) {
+      configuration.name = `${area.name} - ${localize('generic.ordering_position')}: ${area.order}`;
+    }
 
     this.configuration = {
       ...this.configuration,

--- a/src/configurationDefaults.ts
+++ b/src/configurationDefaults.ts
@@ -182,6 +182,7 @@ export const ConfigurationDefaults: StrategyDefaults = {
       _: 2,
     },
   },
+  show_positions: false,
   views: {
     camera: {
       order: 70,

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -29,6 +29,7 @@
     "off": "Aus",
     "on": "Ein",
     "open": "Offen",
+    "ordering_position": "Sortierposition",
     "unavailable": "Nicht verfügbar",
     "unclosed": "Nicht Geschlossen",
     "undisclosed": "Sonstiges",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -29,6 +29,7 @@
     "off": "Off",
     "on": "On",
     "open": "Open",
+    "ordering_position": "Ordering position",
     "unavailable": "Unavailable",
     "unclosed": "Unclosed",
     "undisclosed": "Other",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -29,6 +29,7 @@
     "off": "Apagado",
     "on": "Encendido",
     "open": "Abierto",
+    "ordering_position": "Posición de orden",
     "unavailable": "No Disponible",
     "unclosed": "Sin Cerrar",
     "undisclosed": "Varios",

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -29,6 +29,7 @@
     "off": "Ki",
     "on": "Be",
     "open": "Nyitva",
+    "ordering_position": "Rendezési pozíció",
     "unavailable": "Nem áll rendelkezésre",
     "unclosed": "Nincs bezárva",
     "undisclosed": "Egyéb",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -29,6 +29,7 @@
     "off": "Uit",
     "on": "Aan",
     "open": "Open",
+    "ordering_position": "Sorteer Positie",
     "unavailable": "Onbeschikbaar",
     "unclosed": "Niet Gesloten",
     "undisclosed": "Overige",

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -29,6 +29,7 @@
     "off": "Desligado",
     "on": "Ligado",
     "open": "Aberto",
+    "ordering_position": "Posição de ordenação",
     "unavailable": "Indisponível",
     "unclosed": "Não fechado",
     "undisclosed": "Outro",

--- a/src/types/strategy/strategy-generics.ts
+++ b/src/types/strategy/strategy-generics.ts
@@ -214,6 +214,7 @@ export interface SingleDomainConfig extends Partial<StrategyHeaderCardConfig> {
  * @property {Record<HomeViewSections, boolean>} home_view.hidden - Visibility settings for the home view sections.
  * @property {Object} home_view.stack_count - Controls the number of cards per row in different sections.
  * @property {number} home_view.stack_count._ - Default number of cards per row.
+ * @property {bool} show_positions Whether to show a positional item's position.
  * @property {Record<SupportedViews, StrategyViewConfig>} views - The configurations of views.
  * @property {LovelaceCardConfig[]} quick_access_cards - List of custom-defined cards to show before the area cards.
  */
@@ -232,12 +233,16 @@ export interface StrategyConfig {
     hidden: Record<HomeViewSections, boolean>;
     stack_count: { _: number } & { [K in HomeViewSections]?: K extends 'areas' ? [number, number] : number };
   };
+  show_positions: boolean;
   views: Record<SupportedViews, StrategyViewConfig>;
   quick_access_cards: LovelaceCardConfig[];
 }
 
 /**
  * Represents the default configuration for a strategy.
+ *
+ * @property {AllAreasConfig} areas._ Global default settings applied to all areas.
+ * @property {StrategyArea} areas.undisclosed Forced configuration for the undisclosed area.
  */
 export type StrategyDefaults = Omit<StrategyConfig, 'areas'> & {
   areas: {
@@ -250,10 +255,10 @@ export type StrategyDefaults = Omit<StrategyConfig, 'areas'> & {
  * Strategy Area.
  *
  * @property {boolean} [hidden] True if the entity should be hidden from the dashboard.
- * @property {object[]} [extra_cards] - An array of card configurations.
- *                                      The configured cards are added to the dashboard.
- * @property {number} [order] - Ordering position of the area in the list of available areas.
- * @property {string} [type] - The type of area card.
+ * @property {object[]} [extra_cards] An array of card configurations.
+ *                                    The configured cards are added to the dashboard.
+ * @property {number} [order] Ordering position of the area in the list of available areas.
+ * @property {string} [type] The type of area card.
  */
 export interface StrategyArea extends AreaRegistryEntry {
   extra_cards?: LovelaceCardConfig[];


### PR DESCRIPTION
# Feature Pull Request

## Feature Summary

Assign an order value to each area.

Closes #307 

---

## Motivation and Context

Assigning an order value to each area, gives the user a more granular control of the order of areas.

---

## List of Changes

- Streamline the area registry by using a filter to order areas by name first.
- Ensure the undisclosed area is always included in the list
- Assign an order value to each area, starting at 10 with a gap of 10 in between.

Implemented in the build below and can be tested by following the [Local Installation](https://digilive.github.io/mushroom-strategy/latest/getting-started/installation/#local-installation) instructions, starting from step 2.

[mushroom-strategy.js](https://github.com/user-attachments/files/26454896/mushroom-strategy.js)


## Documentation Updates

See 41dfaf76

---

## Agreements

Please confirm the following by inserting an `x` between the brackets:

- [x] My code adheres to the [contribution guidelines](blob/main/CONTRIBUTING.md) of the project.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
