### PR TITLE
Add implementation of the show_positions option for domains and views

### DIFF
--- a/docs/options/domain-options.md
+++ b/docs/options/domain-options.md
@@ -60,7 +60,9 @@ Possible values for `order` are:
 
 !!! note
 
-    Keep in mind that the domains have a default order as shown in the table above.
+    By default…
+
+    - The strategy pre-assigns a position to each domain, regardless if the domain is hidden or not.
 
 ## Setting options for all domains
 

--- a/docs/options/view-options.md
+++ b/docs/options/view-options.md
@@ -7,17 +7,17 @@ The following views are supported and enabled by default:
 
 | View      | name     | Ordering Position | Type   | Description               |
 |:----------|:---------|:-----------------:|:-------|:--------------------------|
-| `home`    | Home     |        10         | object | The strategy's Home View. |
-| `light`   | Lights   |        20         | object | View to control lights.   |
-| `fan`     | Fans     |        30         | object | View to control fans.     |
-| `cover`   | Covers   |        40         | object | View to control covers.   |
-| `switch`  | Switches |        50         | object | View to control switches. |
-| `climate` | Climates |        60         | object | View to control climates. |
-| `camera`  | Cameras  |        70         | object | View to control cameras.  |
-| `vacuum`  | Vacuums  |        80         | object | View to control vacuums.  |
-| `scene`   | Scenes   |        90         | object | View to control scenes.   |
-| `lock`    | Locks    |        100        | object | View to control locks.    |
-| `valve`   | Valves   |        110        | object | View to control valves.   |
+| `home`    | Home     |     -Infinity     | object | The strategy's Home View. |
+| `light`   | Lights   |        10         | object | View to control lights.   |
+| `fan`     | Fans     |        20         | object | View to control fans.     |
+| `cover`   | Covers   |        30         | object | View to control covers.   |
+| `switch`  | Switches |        40         | object | View to control switches. |
+| `climate` | Climates |        50         | object | View to control climates. |
+| `camera`  | Cameras  |        60         | object | View to control cameras.  |
+| `vacuum`  | Vacuums  |        70         | object | View to control vacuums.  |
+| `scene`   | Scenes   |        80         | object | View to control scenes.   |
+| `lock`    | Locks    |        90         | object | View to control locks.    |
+| `valve`   | Valves   |        100        | object | View to control valves.   |
 
 The `views` group enables you to specify the configuration of a view.
 Each configuration is identified by a view name and can have the following options:
@@ -45,7 +45,10 @@ Possible values for `order` are:
 
 !!! note
 
-    Keep in mind that the build-in views have a default order as shown in the table above.
+    By default…
+
+    - The strategy pre-assigns a position to the build-in views, regardless if the view is hidden or not.
+    - The Home view is assigned the lowest possible `order` value, ensuring it appears first in the list.
     
 ## Example
 

--- a/docs/options/view-options.md
+++ b/docs/options/view-options.md
@@ -49,7 +49,7 @@ Possible values for `order` are:
 
     - The strategy pre-assigns a position to the build-in views, regardless if the view is hidden or not.
     - The Home view is assigned the lowest possible `order` value, ensuring it appears first in the list.
-    
+
 ## Example
 
 ```yaml

--- a/src/Registry.ts
+++ b/src/Registry.ts
@@ -288,7 +288,10 @@ class Registry {
         const orderA = a.order ?? Infinity;
         const orderB = b.order ?? Infinity;
 
-        return orderA - orderB || (a.title ?? '').localeCompare(b.title ?? '');
+        return (
+          orderA - orderB ||
+          (a.title ?? '').localeCompare(b.title ?? '', undefined, { numeric: true, sensitivity: 'base' })
+        );
       })
     ) as Record<string, T>;
   }

--- a/src/configurationDefaults.ts
+++ b/src/configurationDefaults.ts
@@ -185,47 +185,47 @@ export const ConfigurationDefaults: StrategyDefaults = {
   show_positions: false,
   views: {
     camera: {
-      order: 70,
-      hidden: false,
-    },
-    climate: {
       order: 60,
       hidden: false,
     },
-    cover: {
-      order: 40,
-      hidden: false,
-    },
-    fan: {
-      order: 30,
-      hidden: false,
-    },
-    home: {
-      order: 10,
-      hidden: false,
-    },
-    light: {
-      order: 20,
-      hidden: false,
-    },
-    lock: {
-      order: 100,
-      hidden: false,
-    },
-    scene: {
-      order: 90,
-      hidden: false,
-    },
-    switch: {
+    climate: {
       order: 50,
       hidden: false,
     },
-    vacuum: {
+    cover: {
+      order: 30,
+      hidden: false,
+    },
+    fan: {
+      order: 20,
+      hidden: false,
+    },
+    home: {
+      order: -Infinity,
+      hidden: false,
+    },
+    light: {
+      order: 10,
+      hidden: false,
+    },
+    lock: {
+      order: 90,
+      hidden: false,
+    },
+    scene: {
       order: 80,
       hidden: false,
     },
+    switch: {
+      order: 40,
+      hidden: false,
+    },
+    vacuum: {
+      order: 70,
+      hidden: false,
+    },
     valve: {
-      order: 110,
+      order: 100,
       hidden: false,
     },
   },

--- a/src/mushroom-strategy.ts
+++ b/src/mushroom-strategy.ts
@@ -9,6 +9,7 @@ import {
   DashboardInfo,
   isSupportedDomain,
   isSupportedView,
+  SingleDomainConfig,
   StrategyArea,
   StrategyViewConfig,
   ViewInfo,
@@ -22,6 +23,7 @@ import { HomeAssistant } from './types/homeassistant/types';
 import semver from 'semver/preload';
 import { NOTIFICATIONS } from './notifications';
 import MiscellaneousCard from './cards/MiscellaneousCard';
+import { localize } from './utilities/localize';
 
 /**
  * Mushroom Dashboard Strategy.
@@ -48,8 +50,6 @@ class MushroomStrategy extends HTMLTemplateElement {
 
     await MushroomStrategy.handleNotifications(info.hass);
 
-    const views: StrategyViewConfig[] = [];
-
     // Parallelize view imports and creation.
     const viewPromises = Registry.getExposedNames('view')
       .filter(isSupportedView)
@@ -67,18 +67,31 @@ class MushroomStrategy extends HTMLTemplateElement {
         return null;
       });
 
-    const resolvedViews = (await Promise.all(viewPromises)).filter(Boolean) as StrategyViewConfig[];
+    let views: StrategyViewConfig[] = (await Promise.all(viewPromises)).filter(Boolean) as StrategyViewConfig[];
 
-    views.push(...resolvedViews);
+    views.push(...Registry.strategyOptions.extra_views);
 
-    // Extra views
-    if (Registry.strategyOptions.extra_views) {
-      views.push(...Registry.strategyOptions.extra_views);
+    views.sort((viewA, viewB) => {
+      const orderA = viewA.order ?? Infinity;
+      const orderB = viewB.order ?? Infinity;
 
-      views.sort((a, b) => {
-        const diff = (a.order ?? Infinity) - (b.order ?? Infinity);
+      if (orderA !== orderB) {
+        return orderA - orderB;
+      }
 
-        return diff || (a.title ?? '').localeCompare(b.title ?? '');
+      return (viewA.title ?? '').localeCompare(viewB.title ?? '', undefined, {
+        numeric: true,
+        sensitivity: 'base',
+      });
+    });
+
+    if (Registry.strategyOptions.show_positions) {
+      views = views.map((view) => {
+        return {
+          ...view,
+          title: `${view.title}: ${view.order}`,
+          show_icon_and_title: true,
+        };
       });
     }
 
@@ -128,6 +141,11 @@ class MushroomStrategy extends HTMLTemplateElement {
         ...Registry.strategyOptions.domains['_'],
         ...Registry.strategyOptions.domains[domain],
       };
+
+      if (Registry.strategyOptions.show_positions && domain !== '_') {
+        (domainOptions as SingleDomainConfig).subtitle =
+          `${localize('generic.ordering_position')}: ${Registry.strategyOptions.domains[domain].order}`;
+      }
 
       const entities = new RegistryFilter(areaEntities)
         .whereDomain(domain)

--- a/src/types/strategy/strategy-generics.ts
+++ b/src/types/strategy/strategy-generics.ts
@@ -124,12 +124,12 @@ export type RegistryEntry = StrategyArea | DeviceRegistryEntry | EntityRegistryE
 /**
  * View Configuration of the strategy.
  *
- * @property {boolean} hidden - If True, the view is hidden from the dashboard.
- * @property {number} order - Ordering position of the views at the top of the dashboard.
+ * @property {boolean} [hidden] - If True, the view is hidden from the dashboard.
+ * @property {number} [order] - Ordering position of the views at the top of the dashboard.
  */
 export interface StrategyViewConfig extends LovelaceViewConfig {
-  hidden: boolean;
-  order: number;
+  hidden?: boolean;
+  order?: number;
 }
 
 /**

--- a/src/views/AbstractView.ts
+++ b/src/views/AbstractView.ts
@@ -12,6 +12,7 @@ import { logMessage, lvlFatal } from '../utilities/debug';
 import RegistryFilter from '../utilities/RegistryFilter';
 import { stackHorizontal } from '../utilities/cardStacking';
 import { LovelaceSectionRawConfig } from '../types/homeassistant/data/lovelace/config/section';
+import { localize } from '../utilities/localize';
 
 /**
  * Abstract View Class.
@@ -91,13 +92,14 @@ abstract class AbstractView {
 
     // Create card configurations for each area.
     for (const area of Registry.areas) {
+      const areaEntities = new RegistryFilter(domainEntities).whereAreaId(area.area_id).toList();
+
       let areaCards: AbstractCardConfig[] = [];
 
       // Set the target of the Header card to the current area.
       let target: HassServiceTarget = {
         area_id: [area.area_id],
       };
-      const areaEntities = new RegistryFilter(domainEntities).whereAreaId(area.area_id).toList();
 
       // Set the target of the Header card to entities without an area.
       if (area.area_id === 'undisclosed') {
@@ -126,7 +128,15 @@ abstract class AbstractView {
           'headerCardConfiguration' in this.baseConfiguration ? this.baseConfiguration.headerCardConfiguration : {}
         ) as CustomHeaderCardConfig;
 
-        areaCards.unshift(new HeaderCard(target, { title: area.name, ...areaHeaderCardOptions }).createCard());
+        areaCards.unshift(
+          new HeaderCard(target, {
+            title: area.name,
+            ...areaHeaderCardOptions,
+            subtitle: Registry.strategyOptions.show_positions
+              ? `${localize('generic.ordering_position')}: ${area.order}`
+              : undefined,
+          }).createCard()
+        );
 
         viewCards.push({ type: 'vertical-stack', cards: areaCards });
       }


### PR DESCRIPTION
# Feature Pull Request

## Feature Summary

Extends the 'show_positions' option to the items in the top-bar at the dashboard and the domains and area views.

---

## Motivation and Context

It follows up on the changes of #309 as discussed in #304.

Whenever an item can be positioned, its current position can be visualized by setting global strategy option `show_positions` to `true`.

---

## List of Changes

Implemented in the build below and can be tested by following the [Local Installation](https://digilive.github.io/mushroom-strategy/latest/getting-started/installation/#local-installation) instructions, starting from step 2.

[mushroom-strategy.js](https://github.com/user-attachments/files/26479782/mushroom-strategy.js)

---

## Agreements

Please confirm the following by inserting an `x` between the brackets:

- [x] My code adheres to the [contribution guidelines](blob/main/CONTRIBUTING.md) of the project.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
