### PR TITLE
Add French translation

### DIFF
--- a/src/configurationDefaults.ts
+++ b/src/configurationDefaults.ts
@@ -53,7 +53,7 @@ export const ConfigurationDefaults: StrategyDefaults = {
     },
     binary_sensor: {
       order: 20,
-      title: `${localize('sensor.binary')} ` + localize('sensor.sensors'),
+      title: localize('sensor.binary_sensors'),
       show_controls: false,
       hidden: false,
       stack_count: 2,

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -58,7 +58,7 @@
     "selects": "Auswahlen"
   },
   "sensor": {
-    "binary": "Binäre",
+    "binary_sensors": "Binäre Sensoren",
     "sensors": "Sensoren"
   },
   "switch": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -58,7 +58,7 @@
     "selects": "Selects"
   },
   "sensor": {
-    "binary": "Binary",
+    "binary_sensors": "Binary Sensors",
     "sensors": "Sensors"
   },
   "switch": {

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -58,7 +58,7 @@
     "selects": "Seleccionar"
   },
   "sensor": {
-    "binary": "Binario",
+    "binary_sensors": "Binario Sensores",
     "sensors": "Sensores"
   },
   "switch": {

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -1,0 +1,83 @@
+{
+  "camera": {
+    "all_cameras": "Toutes les caméras",
+    "cameras": "Caméras"
+  },
+  "climate": {
+    "all_climates": "Tous les thermostats",
+    "climates": "Thermostats"
+  },
+  "cover": {
+    "all_covers": "Tous les volets",
+    "covers": "Volets"
+  },
+  "fan": {
+    "all_fans": "Tous les ventilateurs",
+    "fans": "Ventilateurs"
+  },
+  "generic": {
+    "all": "Tout",
+    "areas": "Pièces",
+    "busy": "Occupé(e)",
+    "good_afternoon": "Bon après-midi",
+    "good_evening": "Bonsoir",
+    "good_morning": "Bonjour",
+    "hello": "Bonjour",
+    "home": "Accueil",
+    "miscellaneous": "Divers",
+    "numbers": "Nombres",
+    "off": "Éteint(e)",
+    "on": "Allumé(e)",
+    "open": "Ouvert(e)",
+    "ordering_position": "Position de tri",
+    "unavailable": "Indisponible",
+    "unclosed": "Non fermé(e)",
+    "undisclosed": "Non divulgué",
+    "unknown": "Inconnu"
+  },
+  "input_select": {
+    "input_selects": "Sélecteurs d’options"
+  },
+  "light": {
+    "all_lights": "Toutes les lumières",
+    "lights": "Lumières"
+  },
+  "lock": {
+    "all_locks": "Tous les verrous",
+    "locked": "Verrouillé",
+    "locks": "Verrous",
+    "unlocked": "Déverrouillé"
+  },
+  "media_player": {
+    "media_players": "Lecteurs multimédias"
+  },
+  "scene": {
+    "scenes": "Scènes"
+  },
+  "select": {
+    "selects": "Sélecteurs"
+  },
+  "sensor": {
+    "binary_sensors": "Capteurs Binaires",
+    "sensors": "Capteurs"
+  },
+  "switch": {
+    "all_switches": "Tous les interrupteurs",
+    "badge_confirmation": "Attention : cette action éteindra tous les interrupteurs. Êtes-vous sûr de vouloir continuer ?",
+    "switches": "Interrupteurs"
+  },
+  "vacuum": {
+    "all_vacuums": "Tous les aspirateurs",
+    "vacuums": "Aspirateurs"
+  },
+  "valve": {
+    "all_valves": "Toutes les vannes",
+    "valves": "Vannes",
+    "open": "Ouverte",
+    "opening": "Ouverture",
+    "closed": "Fermée",
+    "closing": "Fermeture",
+    "stopped": "Arrêtée",
+    "unclosed": "Non fermée"
+  }
+}

--- a/src/translations/hu.json
+++ b/src/translations/hu.json
@@ -58,7 +58,7 @@
     "selects": "Kiválasztások"
   },
   "sensor": {
-    "binary": "Kétállapotú",
+    "binary_sensors": "Kétállapotú Szenzorok",
     "sensors": "Szenzorok"
   },
   "switch": {

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -58,7 +58,7 @@
     "selects": "Statuslijsten"
   },
   "sensor": {
-    "binary": "Binaire",
+    "binary_sensors": "Binaire Sensoren",
     "sensors": "Sensoren"
   },
   "switch": {

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -58,7 +58,7 @@
     "selects": "Seleção"
   },
   "sensor": {
-    "binary": "Binário",
+    "binary_sensors": "Binário Sensores",
     "sensors": "Sensores"
   },
   "switch": {

--- a/src/utilities/localize.ts
+++ b/src/utilities/localize.ts
@@ -2,6 +2,7 @@ import * as de from '../translations/de.json';
 import * as en from '../translations/en.json';
 import * as es from '../translations/es.json';
 import * as hu from '../translations/hu.json';
+import * as fr from '../translations/fr.json';
 import * as nl from '../translations/nl.json';
 import * as pt_br from '../translations/pt-BR.json';
 import { HomeAssistant } from '../types/homeassistant/types';
@@ -12,6 +13,7 @@ const languages: Record<string, unknown> = {
   de,
   en,
   es,
+  fr,
   hu,
   nl,
   'pt-BR': pt_br,


### PR DESCRIPTION
## Feature Summary

Adds the French language to the strategy.

Closes #315
Discussed in #312

--- 

Implemented in the build below and can be tested by following the [Local Installation](https://digilive.github.io/mushroom-strategy/latest/getting-started/installation/#local-installation) instructions, starting from step 2.

[mushroom-strategy.js](https://github.com/user-attachments/files/26644342/mushroom-strategy.js)
